### PR TITLE
Update game sections with images

### DIFF
--- a/casino-app.tsx
+++ b/casino-app.tsx
@@ -20,8 +20,9 @@ export default function Component() {
   const featuredRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
   const newRef = useRef<HTMLDivElement>(null);
+  const cryptoRef = useRef<HTMLDivElement>(null);
   const jackpotRef = useRef<HTMLDivElement>(null);
-  const popularRef = useRef<HTMLDivElement>(null);
+  const bookRef = useRef<HTMLDivElement>(null);
 
   const scrollLeft = (ref: React.RefObject<HTMLDivElement>) => {
     ref.current?.scrollBy({ left: -150, behavior: "smooth" });
@@ -34,120 +35,93 @@ export default function Component() {
   const featuredGames = [
     {
       id: 1,
-      title: "LUCKY TIGER",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Lucky Tiger",
+      image: "/images/games/lucky_tiger.png",
     },
     {
       id: 2,
-      title: "GATES OF OLYMPUS",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Gates of Olympus",
+      image: "/images/games/gates_of_olympus.png",
     },
     {
       id: 3,
-      title: "SWEET BONANZA 1000",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Sweet Bonanza",
+      image: "/images/games/sweet_bonanza.png",
     },
     {
       id: 4,
-      title: "BUFFALO",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 5,
-      title: "BOOK OF DEAD",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 6,
-      title: "STARBURST",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 7,
-      title: "GONZO'S QUEST",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 8,
-      title: "MEGA MOOLAH",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Buffalo King",
+      image: "/images/games/buffalo_king.png",
     },
   ];
 
   const topGames = [
     {
       id: 1,
-      title: "GATES OF OLYMPUS",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Gates of Olympus",
+      image: "/images/games/gates_of_olympus.png",
     },
     {
       id: 2,
-      title: "BIG BASS BONANZA",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Big Bass Bonanza",
+      image: "/images/games/big_bass_bonanza.png",
     },
     {
       id: 3,
-      title: "JOHN HUNTER",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "John Hunter and Galileo",
+      image: "/images/games/john_hunter_and_galileo.png",
     },
     {
       id: 4,
-      title: "BIG BASS SPLASH",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 5,
-      title: "WOLF GOLD",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 6,
-      title: "THE DOG HOUSE",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 7,
-      title: "RAZOR SHARK",
-      image: "https://placehold.co/160x200?text=Game",
-    },
-    {
-      id: 8,
-      title: "FIRE JOKER",
-      image: "https://placehold.co/160x200?text=Game",
+      title: "Big Bass Return To The Races",
+      image: "/images/games/big_bass_return_to_the_races.png",
     },
   ];
 
   const newGames = [
-    { id: 1, title: "CRYSTAL CAVERNS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 2, title: "PIRATE GOLD", image: "https://placehold.co/160x200?text=Game" },
-    { id: 3, title: "AZTEC GEMS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 4, title: "WILD WEST GOLD", image: "https://placehold.co/160x200?text=Game" },
-    { id: 5, title: "FRUIT PARTY", image: "https://placehold.co/160x200?text=Game" },
-    { id: 6, title: "SUGAR RUSH", image: "https://placehold.co/160x200?text=Game" },
-    { id: 7, title: "MAGIC JOURNEY", image: "https://placehold.co/160x200?text=Game" },
-    { id: 8, title: "DRAGON KINGDOM", image: "https://placehold.co/160x200?text=Game" },
+    { id: 1, title: "The Dog House", image: "/images/games/the_dog_house.png" },
+    { id: 2, title: "Book of Monsters", image: "/images/games/book_of_monsters.png" },
+    { id: 3, title: "Lucky Tiger", image: "/images/games/lucky_tiger.png" },
+    { id: 4, title: "Blitz Super Wheel", image: "/images/games/blitz_super_wheel.png" },
+    { id: 5, title: "Wild Wild Joker", image: "/images/games/wild_wild_joker.png" },
+    { id: 6, title: "Lucky Mouse", image: "/images/games/lucky_mouse.png" },
+  ];
+
+  const cryptoGames = [
+    { id: 1, title: "Aviator", image: "/images/games/crypto_games/aviator.png" },
+    { id: 2, title: "Big Bass Crash", image: "/images/games/crypto_games/big_bass_crash.png" },
+    { id: 3, title: "Crash Duel X", image: "/images/games/crypto_games/crash_duel_x.png" },
+    { id: 4, title: "Cricket Crash", image: "/images/games/crypto_games/cricket_crash.png" },
+    { id: 5, title: "Football Manager", image: "/images/games/crypto_games/football_manager.png" },
+    { id: 6, title: "Magnify Man", image: "/images/games/crypto_games/magnify_man.png" },
+    { id: 7, title: "Need for X", image: "/images/games/crypto_games/need_for_x.png" },
+    { id: 8, title: "Plinko", image: "/images/games/crypto_games/plinko.png" },
+    { id: 9, title: "Save the Hamster", image: "/images/games/crypto_games/save_the_hamster.png" },
+    { id: 10, title: "Spaceman", image: "/images/games/crypto_games/spaceman.png" },
   ];
 
   const jackpotGames = [
-    { id: 1, title: "DIVINE FORTUNE", image: "https://placehold.co/160x200?text=Game" },
-    { id: 2, title: "HALL OF GODS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 3, title: "ARABIAN NIGHTS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 4, title: "COSMIC FORTUNE", image: "https://placehold.co/160x200?text=Game" },
-    { id: 5, title: "TREASURE NILE", image: "https://placehold.co/160x200?text=Game" },
-    { id: 6, title: "KING CASHALOT", image: "https://placehold.co/160x200?text=Game" },
-    { id: 7, title: "MAJOR MILLIONS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 8, title: "CASH SPLASH", image: "https://placehold.co/160x200?text=Game" },
+    { id: 1, title: "5 Lions Gold", image: "/images/games/jackpots/5_lions_gold.png" },
+    { id: 2, title: "Cosmic Cash", image: "/images/games/jackpots/cosmic_cash.png" },
+    { id: 3, title: "Diamond Strike", image: "/images/games/jackpots/diamond_strike.png" },
+    { id: 4, title: "Jackpot Hunter", image: "/images/games/jackpots/jackpot_hunter.png" },
+    { id: 5, title: "Rainforest Magic Bingo", image: "/images/games/jackpots/rainforest_magic_bingo.png" },
   ];
 
-  const popularGames = [
-    { id: 1, title: "STARBURST", image: "https://placehold.co/160x200?text=Game" },
-    { id: 2, title: "MONKEY MADNESS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 3, title: "TORNADO FRUITS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 4, title: "WOLF HOWL", image: "https://placehold.co/160x200?text=Game" },
-    { id: 5, title: "ROULETTE", image: "https://placehold.co/160x200?text=Game" },
-    { id: 6, title: "BLACKJACK", image: "https://placehold.co/160x200?text=Game" },
-    { id: 7, title: "MEGA DREAMS", image: "https://placehold.co/160x200?text=Game" },
-    { id: 8, title: "LUCKY SPINS", image: "https://placehold.co/160x200?text=Game" },
+  const bookOfSlotsGames = [
+    { id: 1, title: "Book of Atlas", image: "/images/games/book_of_slots/book_of_atlas.png" },
+    { id: 2, title: "Book of Champions", image: "/images/games/book_of_slots/book_of_champions.png" },
+    { id: 3, title: "Book of Dead", image: "/images/games/book_of_slots/book_of_dead.png" },
+    { id: 4, title: "Book of Golden Joker", image: "/images/games/book_of_slots/book_of_golden_joker.png" },
+    { id: 5, title: "Book of Light", image: "/images/games/book_of_slots/book_of_light.png" },
+    { id: 6, title: "Book of Mystic", image: "/images/games/book_of_slots/book_of_mystic.png" },
+    { id: 7, title: "Book of Ra", image: "/images/games/book_of_slots/book_of_ra.png" },
+    { id: 8, title: "Book of Rest", image: "/images/games/book_of_slots/book_of_rest.png" },
+    { id: 9, title: "Book of Sirens", image: "/images/games/book_of_slots/book_of_sirens.png" },
+    { id: 10, title: "Book of the Divine", image: "/images/games/book_of_slots/book_of_the_divine.png" },
+    { id: 11, title: "Book of Tut", image: "/images/games/book_of_slots/book_of_tut.png" },
+    { id: 12, title: "Book of Vikings", image: "/images/games/book_of_slots/book_of_vikings.png" },
+    { id: 13, title: "John Hunter and the Book of Tut", image: "/images/games/book_of_slots/john_hunter_and_the_book_of_tut.png" },
   ];
 
   return (
@@ -185,7 +159,7 @@ export default function Component() {
       {/* Welcome Offer Banner */}
       <div className="mx-0 mt-px relative overflow-hidden">
         <Image
-          src="https://placehold.co/1280x720?text=Welcome+Offer+Banner"
+          src="/banner.png"
           alt="Welcome Offer"
           width={1280}
           height={720}
@@ -312,10 +286,48 @@ export default function Component() {
         </div>
       </div>
 
-      {/* Jackpot Games */}
+      {/* Crypto Games */}
       <div className="mt-6 px-4">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Jackpot Games</h2>
+          <h2 className="text-lg font-bold">Crypto Games</h2>
+          <div className="flex gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => scrollLeft(cryptoRef)}
+              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
+            >
+              <ChevronLeft className="w-4 h-4" />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => scrollRight(cryptoRef)}
+              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
+            >
+              <ChevronRight className="w-4 h-4" />
+            </Button>
+          </div>
+        </div>
+
+        <div ref={cryptoRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
+          {cryptoGames.map((game) => (
+            <Card
+              key={game.id}
+              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac]"
+            >
+              <div className="relative aspect-[4/5]">
+                <Image src={game.image} alt={game.title} fill className="object-cover" />
+              </div>
+            </Card>
+          ))}
+        </div>
+      </div>
+
+      {/* Jackpots */}
+      <div className="mt-6 px-4">
+        <div className="flex items-center justify-between mb-4">
+          <h2 className="text-lg font-bold">Jackpots</h2>
           <div className="flex gap-2">
             <Button
               variant="ghost"
@@ -350,15 +362,15 @@ export default function Component() {
         </div>
       </div>
 
-      {/* Popular Games */}
+      {/* Book Of Slots */}
       <div className="mt-6 px-4">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Popular Games</h2>
+          <h2 className="text-lg font-bold">Book Of Slots</h2>
           <div className="flex gap-2">
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => scrollLeft(popularRef)}
+              onClick={() => scrollLeft(bookRef)}
               className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
             >
               <ChevronLeft className="w-4 h-4" />
@@ -366,7 +378,7 @@ export default function Component() {
             <Button
               variant="ghost"
               size="icon"
-              onClick={() => scrollRight(popularRef)}
+              onClick={() => scrollRight(bookRef)}
               className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
             >
               <ChevronRight className="w-4 h-4" />
@@ -374,8 +386,8 @@ export default function Component() {
           </div>
         </div>
 
-        <div ref={popularRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {popularGames.map((game) => (
+        <div ref={bookRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
+          {bookOfSlotsGames.map((game) => (
             <Card
               key={game.id}
               className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac]"


### PR DESCRIPTION
## Summary
- replace welcome banner image
- update game arrays with real images
- add Crypto Games section
- rename Popular Games to Book Of Slots
- rename Jackpot Games to Jackpots

## Testing
- `npm install --legacy-peer-deps`
- `npm run lint` *(fails: requires interactive setup)*

------
https://chatgpt.com/codex/tasks/task_e_68825047a4e8832ea0e92182286f4a60