### PR TITLE
Add FastAPI backend and navigation pages

### DIFF
--- a/app/earn/page.tsx
+++ b/app/earn/page.tsx
@@ -1,0 +1,7 @@
+export default function EarnPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center text-white">
+      <h1 className="text-2xl">Earn Page</h1>
+    </div>
+  );
+}

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center text-white">
+      <h1 className="text-2xl">Profile Page</h1>
+    </div>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,7 @@
+export default function SearchPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center text-white">
+      <h1 className="text-2xl">Search Page</h1>
+    </div>
+  );
+}

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -1,0 +1,7 @@
+export default function WalletPage() {
+  return (
+    <div className="flex min-h-screen items-center justify-center text-white">
+      <h1 className="text-2xl">Wallet Page</h1>
+    </div>
+  );
+}

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,7 @@
+from fastapi import FastAPI
+
+app = FastAPI()
+
+@app.get("/")
+def read_root():
+    return {"message": "Hello from FastAPI"}

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn

--- a/casino-app.tsx
+++ b/casino-app.tsx
@@ -6,13 +6,14 @@ import { Card } from "@/components/ui/card";
 import {
   Home,
   Search,
-  Gift,
   Wallet,
   DollarSign,
+  User,
   ChevronLeft,
   ChevronRight,
 } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
 
 export default function Component() {
   const [balance] = useState("0.00000");
@@ -403,40 +404,35 @@ export default function Component() {
       {/* Bottom Navigation */}
       <div className="fixed bottom-0 left-0 right-0 bg-black/40 backdrop-blur-md border-t border-purple-700/50">
         <div className="flex items-center justify-around py-2">
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-[#ff3cac] drop-shadow-[0_0_6px_#ff3cac] p-2"
-          >
-            <Home className="w-5 h-5" />
-            <span className="text-xs">Home</span>
+          <Button asChild variant="ghost" className="flex flex-col items-center gap-1 text-[#ff3cac] drop-shadow-[0_0_6px_#ff3cac] p-2">
+            <Link href="/">
+              <Home className="w-5 h-5" />
+              <span className="text-xs">Home</span>
+            </Link>
           </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Search className="w-5 h-5" />
-            <span className="text-xs">Search</span>
+          <Button asChild variant="ghost" className="flex flex-col items-center gap-1 text-gray-400 p-2">
+            <Link href="/search">
+              <Search className="w-5 h-5" />
+              <span className="text-xs">Search</span>
+            </Link>
           </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Gift className="w-5 h-5" />
-            <span className="text-xs">Offers</span>
+          <Button asChild variant="ghost" className="flex flex-col items-center gap-1 text-gray-400 p-2">
+            <Link href="/wallet">
+              <Wallet className="w-5 h-5" />
+              <span className="text-xs">Wallet</span>
+            </Link>
           </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Wallet className="w-5 h-5" />
-            <span className="text-xs">Wallet</span>
+          <Button asChild variant="ghost" className="flex flex-col items-center gap-1 text-gray-400 p-2">
+            <Link href="/earn">
+              <DollarSign className="w-5 h-5" />
+              <span className="text-xs">Earn</span>
+            </Link>
           </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <DollarSign className="w-5 h-5" />
-            <span className="text-xs">Earn</span>
+          <Button asChild variant="ghost" className="flex flex-col items-center gap-1 text-gray-400 p-2">
+            <Link href="/profile">
+              <User className="w-5 h-5" />
+              <span className="text-xs">Profile</span>
+            </Link>
           </Button>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- create blank pages for Search, Wallet, Earn and Profile
- update footer navigation and icons
- wire navigation buttons to new pages
- add a simple FastAPI backend with requirements

## Testing
- `pnpm run build`
- `pnpm run lint` *(fails: project prompts for ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68825ed601dc832e8b236696da9f5450