### PR TITLE
Add navigation and blank pages

### DIFF
--- a/app/earn/page.tsx
+++ b/app/earn/page.tsx
@@ -1,0 +1,7 @@
+export default function EarnPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-center text-lg font-bold">Earn Page</h1>
+    </main>
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,7 @@
-import type { Metadata } from 'next'
-import './globals.css'
+import type { Metadata } from "next";
+import "./globals.css";
+import Header from "@/components/header";
+import FooterNav from "@/components/footer-nav";
 
 export const metadata: Metadata = {
   title: 'v0 App',
@@ -14,7 +16,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <div className="min-h-screen bg-gradient-to-b from-[#240046] to-[#2e003e] text-white">
+          <Header />
+          {children}
+          <FooterNav />
+          <div className="h-20" />
+        </div>
+      </body>
     </html>
   )
 }

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,0 +1,7 @@
+export default function ProfilePage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-center text-lg font-bold">Profile Page</h1>
+    </main>
+  );
+}

--- a/app/search/page.tsx
+++ b/app/search/page.tsx
@@ -1,0 +1,7 @@
+export default function SearchPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-center text-lg font-bold">Search Page</h1>
+    </main>
+  );
+}

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -1,0 +1,7 @@
+export default function WalletPage() {
+  return (
+    <main className="p-4">
+      <h1 className="text-center text-lg font-bold">Wallet Page</h1>
+    </main>
+  );
+}

--- a/casino-app.tsx
+++ b/casino-app.tsx
@@ -1,22 +1,12 @@
 "use client";
 
-import { useRef, useState } from "react";
+import { useRef } from "react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
-import {
-  Home,
-  Search,
-  Gift,
-  Wallet,
-  DollarSign,
-  ChevronLeft,
-  ChevronRight,
-} from "lucide-react";
+import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "next/image";
 
 export default function Component() {
-  const [balance] = useState("0.00000");
-
   const featuredRef = useRef<HTMLDivElement>(null);
   const topRef = useRef<HTMLDivElement>(null);
   const newRef = useRef<HTMLDivElement>(null);
@@ -125,37 +115,7 @@ export default function Component() {
   ];
 
   return (
-    <div className="min-h-screen bg-gradient-to-b from-[#240046] to-[#2e003e] text-white">
-      {/* Header */}
-      <div className="sticky top-0 z-50 flex items-center justify-between p-4 bg-black/20 backdrop-blur-md">
-        <div className="flex items-center gap-2">
-          <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center">
-            <span className="text-white font-bold text-sm">C</span>
-          </div>
-          <span className="font-bold text-lg">Crashino</span>
-        </div>
-
-        <div className="flex items-center gap-1 bg-black/30 rounded-full px-3 py-1">
-          <span className="text-base">🪙</span>
-          <span className="text-sm font-medium">{balance}</span>
-        </div>
-
-        <Button
-          variant="ghost"
-          size="icon"
-          className="w-10 h-10 rounded-full overflow-hidden p-0"
-        >
-          <Image
-            src="https://placehold.co/40x40"
-            alt="Profile"
-            width={40}
-            height={40}
-            className="object-cover"
-          />
-        </Button>
-      </div>
-
-
+    <div>
       {/* Welcome Offer Banner */}
       <div className="mx-0 mt-px relative overflow-hidden">
         <Image
@@ -400,49 +360,7 @@ export default function Component() {
         </div>
       </div>
 
-      {/* Bottom Navigation */}
-      <div className="fixed bottom-0 left-0 right-0 bg-black/40 backdrop-blur-md border-t border-purple-700/50">
-        <div className="flex items-center justify-around py-2">
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-[#ff3cac] drop-shadow-[0_0_6px_#ff3cac] p-2"
-          >
-            <Home className="w-5 h-5" />
-            <span className="text-xs">Home</span>
-          </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Search className="w-5 h-5" />
-            <span className="text-xs">Search</span>
-          </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Gift className="w-5 h-5" />
-            <span className="text-xs">Offers</span>
-          </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <Wallet className="w-5 h-5" />
-            <span className="text-xs">Wallet</span>
-          </Button>
-          <Button
-            variant="ghost"
-            className="flex flex-col items-center gap-1 text-gray-400 p-2"
-          >
-            <DollarSign className="w-5 h-5" />
-            <span className="text-xs">Earn</span>
-          </Button>
-        </div>
-      </div>
 
-      {/* Spacer for bottom navigation */}
-      <div className="h-20"></div>
     </div>
   );
 }

--- a/components/footer-nav.tsx
+++ b/components/footer-nav.tsx
@@ -1,0 +1,36 @@
+"use client";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+import { Home, Search, Wallet, DollarSign, User } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const navItems = [
+  { href: "/", label: "Home", icon: Home },
+  { href: "/search", label: "Search", icon: Search },
+  { href: "/wallet", label: "Wallet", icon: Wallet },
+  { href: "/earn", label: "Earn", icon: DollarSign },
+  { href: "/profile", label: "Profile", icon: User },
+];
+
+export default function FooterNav() {
+  const pathname = usePathname();
+  return (
+    <div className="fixed bottom-0 left-0 right-0 bg-black/40 backdrop-blur-md border-t border-purple-700/50">
+      <div className="flex items-center justify-around py-2">
+        {navItems.map(({ href, label, icon: Icon }) => (
+          <Button
+            key={href}
+            asChild
+            variant="ghost"
+            className={`flex flex-col items-center gap-1 p-2 ${pathname === href ? "text-[#ff3cac] drop-shadow-[0_0_6px_#ff3cac]" : "text-gray-400"}`}
+          >
+            <Link href={href}>
+              <Icon className="w-5 h-5" />
+              <span className="text-xs">{label}</span>
+            </Link>
+          </Button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,0 +1,31 @@
+"use client";
+import { useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+
+export default function Header() {
+  const [balance] = useState("0.00000");
+  return (
+    <div className="sticky top-0 z-50 flex items-center justify-between p-4 bg-black/20 backdrop-blur-md">
+      <div className="flex items-center gap-2">
+        <div className="w-8 h-8 bg-purple-600 rounded-full flex items-center justify-center">
+          <span className="text-white font-bold text-sm">C</span>
+        </div>
+        <span className="font-bold text-lg">Crashino</span>
+      </div>
+      <div className="flex items-center gap-1 bg-black/30 rounded-full px-3 py-1">
+        <span className="text-base">🪙</span>
+        <span className="text-sm font-medium">{balance}</span>
+      </div>
+      <Button variant="ghost" size="icon" className="w-10 h-10 rounded-full overflow-hidden p-0">
+        <Image
+          src="https://placehold.co/40x40"
+          alt="Profile"
+          width={40}
+          height={40}
+          className="object-cover"
+        />
+      </Button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- put header and footer in layout
- create pages for search, wallet, earn and profile
- remove offers button and highlight active nav item
- strip header and footer from home

## Testing
- `npm install --legacy-peer-deps`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_688265ab893c832e96d6ebe24953c9e5