### PR TITLE
Add env loading to Telegram bot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ next-env.d.ts
 .DS_Store
 Thumbs.db
 .replit
+.env

--- a/bot/README.md
+++ b/bot/README.md
@@ -1,0 +1,33 @@
+# Bot Setup
+
+This directory contains a simple Telegram bot implemented with `aiogram`.
+
+## Requirements
+
+* Python 3.12
+* [`aiogram`](https://pypi.org/project/aiogram/) library
+* [`python-dotenv`](https://pypi.org/project/python-dotenv/) to load `.env` files
+
+Install the dependencies:
+
+```bash
+pip install aiogram python-dotenv
+```
+
+## Configuration
+
+Create a `.env` file in this directory with the following variables:
+
+```
+TELEGRAM_BOT_TOKEN=<your bot token>
+WEBAPP_URL=<url to open from the button>
+```
+
+## Running the Bot
+
+Execute the bot with:
+
+```bash
+python bot/main.py
+```
+

--- a/bot/main.py
+++ b/bot/main.py
@@ -1,0 +1,47 @@
+import os
+import asyncio
+import logging
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from aiogram import Bot, Dispatcher
+from aiogram.filters import Command
+
+from aiogram.types import (
+    Message,
+    InlineKeyboardMarkup,
+    InlineKeyboardButton,
+    WebAppInfo,
+)
+
+# Load variables from .env file if present
+load_dotenv(dotenv_path=Path(__file__).resolve().parent / ".env")
+
+# Read required environment variables
+TELEGRAM_BOT_TOKEN = os.environ["TELEGRAM_BOT_TOKEN"]
+WEBAPP_URL = os.environ["WEBAPP_URL"]
+
+bot = Bot(TELEGRAM_BOT_TOKEN)
+dp = Dispatcher()
+
+@dp.message(Command("start"))
+async def start(message: Message):
+    keyboard = InlineKeyboardMarkup(
+        inline_keyboard=[
+            [
+                InlineKeyboardButton(
+                    text="Open WebApp",
+                    web_app=WebAppInfo(url=WEBAPP_URL),
+                )
+            ]
+        ]
+    )
+    await message.answer("Welcome!", reply_markup=keyboard)
+
+async def main():
+    logging.basicConfig(level=logging.INFO)
+    await dp.start_polling(bot)
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## Summary
- use `python-dotenv` to load variables from `.env`
- document .env usage and python-dotenv in bot README
- ignore `.env` by default

## Testing
- `python -m py_compile bot/main.py`
- `npm run lint` *(fails: `next` not found)*
- `npm run build` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6882e94d1a98832ebf413dba18f793fc