### PR TITLE
Integrate Telegram user data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,35 @@
+# TelBet Frontend
+
+This project is a simple Next.js UI meant to be embedded inside a Telegram Web App.
+
+## Telegram Web App Integration
+
+The UI reads basic user information from `window.Telegram.WebApp.initDataUnsafe.user` when running inside Telegram. The object should contain at least the following fields:
+
+- `id`
+- `first_name`
+- `last_name`
+- `username`
+- `photo_url`
+
+Example snippet that mocks the data during local development:
+
+```html
+<script>
+  window.Telegram = {
+    WebApp: {
+      initDataUnsafe: {
+        user: {
+          id: 123,
+          first_name: 'John',
+          last_name: 'Doe',
+          username: 'jdoe',
+          photo_url: 'https://placehold.co/64x64'
+        }
+      }
+    }
+  }
+</script>
+```
+
+When no Telegram user data is available the UI falls back to placeholder images and names.

--- a/app/profile/page.tsx
+++ b/app/profile/page.tsx
@@ -1,18 +1,23 @@
+"use client";
 import Image from "next/image";
+import useTelegramUser from "@/hooks/useTelegramUser";
 
 export default function ProfilePage() {
+  const user = useTelegramUser();
   return (
     <main className="p-4 flex flex-col gap-4">
       <div className="flex items-center gap-4">
         <Image
-          src="https://placehold.co/64x64"
+          src={user?.photo_url ?? "https://placehold.co/64x64"}
           alt="Profile"
           width={64}
           height={64}
           className="rounded-full"
         />
         <div>
-          <p className="font-bold">John Doe</p>
+          <p className="font-bold">
+            {user ? `${user.first_name} ${user.last_name ?? ""}` : "John Doe"}
+          </p>
           <p className="text-sm opacity-70">User since: Jan 1, 2024</p>
         </div>
       </div>

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -1,10 +1,12 @@
 "use client";
 import { useState } from "react";
+import useTelegramUser from "@/hooks/useTelegramUser";
 import Image from "next/image";
 import { Button } from "@/components/ui/button";
 
 export default function Header() {
   const [balance] = useState("0.000");
+  const user = useTelegramUser();
   return (
     <div className="sticky top-0 z-50 flex items-center justify-between p-4 bg-black/20 backdrop-blur-md">
       <div className="flex items-center gap-2">
@@ -17,8 +19,8 @@ export default function Header() {
       </div>
       <Button variant="ghost" size="icon" className="w-10 h-10 rounded-full overflow-hidden p-0 ml-3">
         <Image
-          src="https://placehold.co/40x40"
-          alt="Profile"
+          src={user?.photo_url ?? "https://placehold.co/40x40"}
+          alt={user ? `${user.first_name} ${user.last_name ?? ""}` : "Profile"}
           width={40}
           height={40}
           className="object-cover"

--- a/hooks/useTelegramUser.ts
+++ b/hooks/useTelegramUser.ts
@@ -1,0 +1,28 @@
+'use client';
+import { useEffect, useState } from 'react';
+
+export interface TelegramUser {
+  id: number;
+  first_name: string;
+  last_name?: string;
+  username?: string;
+  photo_url?: string;
+}
+
+export default function useTelegramUser() {
+  const [user, setUser] = useState<TelegramUser | null>(null);
+
+  useEffect(() => {
+    const tgUser = (typeof window !== 'undefined')
+      ? (window as any).Telegram?.WebApp?.initDataUnsafe?.user
+      : undefined;
+    if (tgUser) {
+      const { id, first_name, last_name, username, photo_url } = tgUser;
+      setUser({ id, first_name, last_name, username, photo_url });
+    } else {
+      setUser(null);
+    }
+  }, []);
+
+  return user;
+}


### PR DESCRIPTION
## Summary
- add a `useTelegramUser` hook for reading `window.Telegram.WebApp` data
- show Telegram avatar in the header
- display Telegram name and avatar on the profile page
- document Telegram WebApp data in README

## Testing
- `npx tsc -p tsconfig.json` *(fails: several existing errors)*
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_6882ec48c214832eac9d4a99014e43eb