### PR TITLE
Load bot env vars dynamically

### DIFF
--- a/app/api/bot-env/route.ts
+++ b/app/api/bot-env/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+import dotenv from 'dotenv'
+
+export async function GET() {
+  try {
+    const envPath = path.join(process.cwd(), 'bot/.env')
+    const data = fs.readFileSync(envPath)
+    const parsed = dotenv.parse(data)
+    return NextResponse.json({
+      BOT_USERNAME: parsed.BOT_USERNAME || '',
+      TON_ADDRESS: parsed.TON_ADDRESS || '',
+      TON_TAG: parsed.TON_TAG || '',
+    })
+  } catch {
+    return NextResponse.json({ BOT_USERNAME: '', TON_ADDRESS: '', TON_TAG: '' })
+  }
+}

--- a/app/earn/page.tsx
+++ b/app/earn/page.tsx
@@ -4,9 +4,11 @@ import Image from "next/image";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Copy, Users, DollarSign, Percent } from "lucide-react";
+import useBotEnv from "@/hooks/useBotEnv";
 
 export default function EarnPage() {
-  const affiliate = "https://t.me/example_bot";
+  const { BOT_USERNAME } = useBotEnv();
+  const affiliate = `https://t.me/${BOT_USERNAME}`;
 
   const copy = async (text: string) => {
     try {

--- a/app/wallet/page.tsx
+++ b/app/wallet/page.tsx
@@ -11,15 +11,16 @@ import {
   SelectItem,
 } from "@/components/ui/select";
 import { ArrowDown, ArrowUp, Copy } from "lucide-react";
+import useBotEnv from "@/hooks/useBotEnv";
 
 export default function WalletPage() {
+  const { TON_ADDRESS, TON_TAG } = useBotEnv();
   const [tab, setTab] = useState<"deposit" | "withdraw">("deposit");
   const [amount, setAmount] = useState("");
   const [showAlert, setShowAlert] = useState(false);
 
-  const address =
-    "EQC1234567890abcdef1234567890abcdef1234567890abcdef1234567890";
-  const tag = "654321";
+  const address = TON_ADDRESS;
+  const tag = TON_TAG;
 
   useEffect(() => {
     if (!showAlert) return;

--- a/casino-app.tsx
+++ b/casino-app.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef } from "react";
+import useBotEnv from "@/hooks/useBotEnv";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ChevronLeft, ChevronRight } from "lucide-react";
@@ -13,6 +14,7 @@ export default function Component() {
   const cryptoRef = useRef<HTMLDivElement>(null);
   const jackpotRef = useRef<HTMLDivElement>(null);
   const bookRef = useRef<HTMLDivElement>(null);
+  const { BOT_USERNAME } = useBotEnv();
 
   const scrollLeft = (ref: React.RefObject<HTMLDivElement>) => {
     ref.current?.scrollBy({ left: -150, behavior: "smooth" });
@@ -368,8 +370,11 @@ export default function Component() {
 
       {/* Contact Information */}
       <div className="mt-10 mb-20 px-4 text-center">
-        <a href="https://t.me/TelBet_Demo_Bot" className="text-pink-400 text-sm hover:underline">
-          @TelBet_Demo_Bot
+        <a
+          href={`https://t.me/${BOT_USERNAME}`}
+          className="text-pink-400 text-sm hover:underline"
+        >
+          {BOT_USERNAME ? `@${BOT_USERNAME}` : ""}
         </a>
       </div>
 

--- a/hooks/useBotEnv.ts
+++ b/hooks/useBotEnv.ts
@@ -1,0 +1,25 @@
+'use client'
+import { useEffect, useState } from 'react'
+
+export interface BotEnv {
+  BOT_USERNAME: string
+  TON_ADDRESS: string
+  TON_TAG: string
+}
+
+export default function useBotEnv() {
+  const [env, setEnv] = useState<BotEnv>({
+    BOT_USERNAME: '',
+    TON_ADDRESS: '',
+    TON_TAG: '',
+  })
+
+  useEffect(() => {
+    fetch('/api/bot-env')
+      .then((res) => res.json())
+      .then((data: BotEnv) => setEnv(data))
+      .catch(() => {})
+  }, [])
+
+  return env
+}

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "cmdk": "1.0.4",
     "components": "link:@/components",
     "date-fns": "4.1.0",
+    "dotenv": "^17.2.1",
     "embla-carousel-react": "8.5.1",
     "input-otp": "1.4.1",
     "lucide-react": "^0.454.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       date-fns:
         specifier: 4.1.0
         version: 4.1.0
+      dotenv:
+        specifier: ^17.2.1
+        version: 17.2.1
       embla-carousel-react:
         specifier: 8.5.1
         version: 8.5.1(react@19.1.0)
@@ -1282,6 +1285,10 @@ packages:
 
   dom-helpers@5.2.1:
     resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dotenv@17.2.1:
+    resolution: {integrity: sha512-kQhDYKZecqnM0fCnzI5eIv5L4cAe/iRI+HqMbO/hbRdTAeXDG+M9FjipUxNfbARuEg4iHIbhnhs78BCHNbSxEQ==}
+    engines: {node: '>=12'}
 
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
@@ -2957,6 +2964,8 @@ snapshots:
     dependencies:
       '@babel/runtime': 7.28.2
       csstype: 3.1.3
+
+  dotenv@17.2.1: {}
 
   eastasianwidth@0.2.0: {}
 


### PR DESCRIPTION
## Summary
- add API route to expose bot env variables
- create hook to fetch these values client-side
- show bot username on the home page footer
- use env vars for affiliate link on Earn page
- use env vars for address/tag on Wallet page
- add `dotenv` dependency

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68838132cc60832eaba287454877a47e