### PR TITLE
Replace sample games with real ones and add play flow

### DIFF
--- a/app/api/game-url/route.ts
+++ b/app/api/game-url/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server'
+import fs from 'fs'
+import path from 'path'
+
+export async function GET(req: NextRequest) {
+  const { searchParams } = new URL(req.url)
+  const code = searchParams.get('code')
+  if (!code) {
+    return NextResponse.json({ error: 'Missing code' }, { status: 400 })
+  }
+
+  try {
+    const configPath = path.join(process.cwd(), 'game-api.json')
+    const raw = fs.readFileSync(configPath, 'utf-8')
+    const { headers } = JSON.parse(raw)
+
+    const res = await fetch(
+      `https://www.playamo.com/api/games/launch_options/${code}`,
+      { headers }
+    )
+    const data = await res.json()
+    return NextResponse.json(data)
+  } catch (e) {
+    return NextResponse.json({ error: 'request failed' }, { status: 500 })
+  }
+}

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -1,0 +1,87 @@
+"use client";
+
+import { useSearchParams, useRouter } from "next/navigation";
+import { useEffect, useState } from "react";
+import Image from "next/image";
+import { Button } from "@/components/ui/button";
+import { ArrowLeft } from "lucide-react";
+import useBotEnv from "@/hooks/useBotEnv";
+
+interface Game {
+  code: string;
+  title: string;
+  image: string;
+}
+
+export default function GamePage() {
+  const searchParams = useSearchParams();
+  const code = searchParams.get("code");
+  const router = useRouter();
+  const { BOT_USERNAME } = useBotEnv();
+  const [game, setGame] = useState<Game | null>(null);
+
+  useEffect(() => {
+    fetch("/games.json")
+      .then((res) => res.json())
+      .then((data) => {
+        const allGames: Game[] = data.sections.flatMap((s: { games: Game[] }) => s.games);
+        const found = allGames.find((g) => g.code === code);
+        setGame(found || null);
+      })
+      .catch(() => {});
+  }, [code]);
+
+  const handlePlay = async () => {
+    if (!code) return;
+    try {
+      const res = await fetch(`/api/game-url?code=${encodeURIComponent(code)}`);
+      const data = await res.json();
+      const url = data.launch_options?.game_url;
+      if (url) {
+        const gameUrl = new URL(url);
+        gameUrl.searchParams.delete("ip");
+        if (BOT_USERNAME) {
+          const botLink = `https://t.me/${BOT_USERNAME}`;
+          gameUrl.searchParams.set("return_url", encodeURIComponent(botLink));
+        }
+        window.location.href = gameUrl.toString();
+      }
+    } catch {
+      // ignore
+    }
+  };
+
+  if (!game) return null;
+
+  return (
+    <div>
+      <button
+        onClick={() => router.back()}
+        className="flex items-center text-pink-500 m-4"
+      >
+        <ArrowLeft className="w-5 h-5 mr-1" /> Back
+      </button>
+      <div className="relative w-full h-40 sm:h-56 mb-4">
+        <Image src={game.image} alt={game.title} fill className="object-cover blur-xl" />
+        <div className="absolute top-1/2 left-4 -translate-y-1/2 flex">
+          <Image
+            src={game.image}
+            alt={game.title}
+            width={120}
+            height={150}
+            className="rounded-lg"
+          />
+          <div className="ml-4 flex flex-col justify-center">
+            <h1 className="text-xl font-bold">{game.title}</h1>
+            <Button
+              onClick={handlePlay}
+              className="mt-2 bg-pink-500 hover:bg-pink-600 rounded-full"
+            >
+              Play Now
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/casino-app.tsx
+++ b/casino-app.tsx
@@ -1,120 +1,43 @@
 "use client";
 
-import { useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import useBotEnv from "@/hooks/useBotEnv";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { ChevronLeft, ChevronRight } from "lucide-react";
 import Image from "next/image";
+import Link from "next/link";
+
+interface Game {
+  code: string;
+  title: string;
+  image: string;
+}
+
+interface Section {
+  title: string;
+  games: Game[];
+}
 
 export default function Component() {
-  const featuredRef = useRef<HTMLDivElement>(null);
-  const topRef = useRef<HTMLDivElement>(null);
-  const newRef = useRef<HTMLDivElement>(null);
-  const cryptoRef = useRef<HTMLDivElement>(null);
-  const jackpotRef = useRef<HTMLDivElement>(null);
-  const bookRef = useRef<HTMLDivElement>(null);
   const { BOT_USERNAME } = useBotEnv();
+  const [sections, setSections] = useState<Section[]>([]);
+  const sectionRefs = useRef<Record<string, HTMLDivElement | null>>({});
 
-  const scrollLeft = (ref: React.RefObject<HTMLDivElement>) => {
-    ref.current?.scrollBy({ left: -150, behavior: "smooth" });
+  useEffect(() => {
+    fetch("/games.json")
+      .then((res) => res.json())
+      .then((data) => setSections(data.sections || []))
+      .catch(() => {});
+  }, []);
+
+  const scrollLeft = (title: string) => {
+    sectionRefs.current[title]?.scrollBy({ left: -150, behavior: "smooth" });
   };
 
-  const scrollRight = (ref: React.RefObject<HTMLDivElement>) => {
-    ref.current?.scrollBy({ left: 150, behavior: "smooth" });
+  const scrollRight = (title: string) => {
+    sectionRefs.current[title]?.scrollBy({ left: 150, behavior: "smooth" });
   };
-
-  const featuredGames = [
-    {
-      id: 1,
-      title: "Lucky Tiger",
-      image: "/images/games/lucky_tiger.png",
-    },
-    {
-      id: 2,
-      title: "Gates of Olympus",
-      image: "/images/games/gates_of_olympus.png",
-    },
-    {
-      id: 3,
-      title: "Sweet Bonanza",
-      image: "/images/games/sweet_bonanza.png",
-    },
-    {
-      id: 4,
-      title: "Buffalo King",
-      image: "/images/games/buffalo_king.png",
-    },
-  ];
-
-  const topGames = [
-    {
-      id: 1,
-      title: "Gates of Olympus",
-      image: "/images/games/gates_of_olympus.png",
-    },
-    {
-      id: 2,
-      title: "Big Bass Bonanza",
-      image: "/images/games/big_bass_bonanza.png",
-    },
-    {
-      id: 3,
-      title: "John Hunter and Galileo",
-      image: "/images/games/john_hunter_and_galileo.png",
-    },
-    {
-      id: 4,
-      title: "Big Bass Return To The Races",
-      image: "/images/games/big_bass_return_to_the_races.png",
-    },
-  ];
-
-  const newGames = [
-    { id: 1, title: "The Dog House", image: "/images/games/the_dog_house.png" },
-    { id: 2, title: "Book of Monsters", image: "/images/games/book_of_monsters.png" },
-    { id: 3, title: "Lucky Tiger", image: "/images/games/lucky_tiger.png" },
-    { id: 4, title: "Blitz Super Wheel", image: "/images/games/blitz_super_wheel.png" },
-    { id: 5, title: "Wild Wild Joker", image: "/images/games/wild_wild_joker.png" },
-    { id: 6, title: "Lucky Mouse", image: "/images/games/lucky_mouse.png" },
-  ];
-
-  const cryptoGames = [
-    { id: 1, title: "Aviator", image: "/images/games/crypto_games/aviator.png" },
-    { id: 2, title: "Big Bass Crash", image: "/images/games/crypto_games/big_bass_crash.png" },
-    { id: 3, title: "Crash Duel X", image: "/images/games/crypto_games/crash_duel_x.png" },
-    { id: 4, title: "Cricket Crash", image: "/images/games/crypto_games/cricket_crash.png" },
-    { id: 5, title: "Football Manager", image: "/images/games/crypto_games/football_manager.png" },
-    { id: 6, title: "Magnify Man", image: "/images/games/crypto_games/magnify_man.png" },
-    { id: 7, title: "Need for X", image: "/images/games/crypto_games/need_for_x.png" },
-    { id: 8, title: "Plinko", image: "/images/games/crypto_games/plinko.png" },
-    { id: 9, title: "Save the Hamster", image: "/images/games/crypto_games/save_the_hamster.png" },
-    { id: 10, title: "Spaceman", image: "/images/games/crypto_games/spaceman.png" },
-  ];
-
-  const jackpotGames = [
-    { id: 1, title: "5 Lions Gold", image: "/images/games/jackpots/5_lions_gold.png" },
-    { id: 2, title: "Cosmic Cash", image: "/images/games/jackpots/cosmic_cash.png" },
-    { id: 3, title: "Diamond Strike", image: "/images/games/jackpots/diamond_strike.png" },
-    { id: 4, title: "Jackpot Hunter", image: "/images/games/jackpots/jackpot_hunter.png" },
-    { id: 5, title: "Rainforest Magic Bingo", image: "/images/games/jackpots/rainforest_magic_bingo.png" },
-  ];
-
-  const bookOfSlotsGames = [
-    { id: 1, title: "Book of Atlas", image: "/images/games/book_of_slots/book_of_atlas.png" },
-    { id: 2, title: "Book of Champions", image: "/images/games/book_of_slots/book_of_champions.png" },
-    { id: 3, title: "Book of Dead", image: "/images/games/book_of_slots/book_of_dead.png" },
-    { id: 4, title: "Book of Golden Joker", image: "/images/games/book_of_slots/book_of_golden_joker.png" },
-    { id: 5, title: "Book of Light", image: "/images/games/book_of_slots/book_of_light.png" },
-    { id: 6, title: "Book of Mystic", image: "/images/games/book_of_slots/book_of_mystic.png" },
-    { id: 7, title: "Book of Ra", image: "/images/games/book_of_slots/book_of_ra.png" },
-    { id: 8, title: "Book of Rest", image: "/images/games/book_of_slots/book_of_rest.png" },
-    { id: 9, title: "Book of Sirens", image: "/images/games/book_of_slots/book_of_sirens.png" },
-    { id: 10, title: "Book of the Divine", image: "/images/games/book_of_slots/book_of_the_divine.png" },
-    { id: 11, title: "Book of Tut", image: "/images/games/book_of_slots/book_of_tut.png" },
-    { id: 12, title: "Book of Vikings", image: "/images/games/book_of_slots/book_of_vikings.png" },
-    { id: 13, title: "John Hunter and the Book of Tut", image: "/images/games/book_of_slots/john_hunter_and_the_book_of_tut.png" },
-  ];
 
   return (
     <div>
@@ -135,233 +58,46 @@ export default function Component() {
         </div>
       </div>
 
-      {/* Featured Games */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Featured</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(featuredRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(featuredRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
+      {sections.map((section) => (
+        <div key={section.title} className="mt-6 px-4">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-bold">{section.title}</h2>
+            <div className="flex gap-2">
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => scrollLeft(section.title)}
+                className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
+              >
+                <ChevronLeft className="w-4 h-4" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => scrollRight(section.title)}
+                className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
+              >
+                <ChevronRight className="w-4 h-4" />
+              </Button>
+            </div>
+          </div>
+
+          <div
+            ref={(el) => (sectionRefs.current[section.title] = el)}
+            className="flex gap-1 overflow-x-auto scrollbar-hide pb-2"
+          >
+            {section.games.map((game) => (
+              <Link key={game.code} href={`/game?code=${encodeURIComponent(game.code)}`}>
+                <Card className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none">
+                  <div className="relative aspect-[4/5]">
+                    <Image src={game.image} alt={game.title} fill className="object-cover" />
+                  </div>
+                </Card>
+              </Link>
+            ))}
           </div>
         </div>
-
-        <div ref={featuredRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {featuredGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* Top Games */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Top Games</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(topRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(topRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div ref={topRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {topGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* New Games */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">New Games</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(newRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(newRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div ref={newRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {newGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* Crypto Games */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Crypto Games</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(cryptoRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(cryptoRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div ref={cryptoRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {cryptoGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* Jackpots */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Jackpots</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(jackpotRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(jackpotRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div ref={jackpotRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {jackpotGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
-
-      {/* Book Of Slots */}
-      <div className="mt-6 px-4">
-        <div className="flex items-center justify-between mb-4">
-          <h2 className="text-lg font-bold">Book Of Slots</h2>
-          <div className="flex gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollLeft(bookRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronLeft className="w-4 h-4" />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => scrollRight(bookRef)}
-              className="w-8 h-8 bg-pink-500 hover:bg-pink-600 rounded-full"
-            >
-              <ChevronRight className="w-4 h-4" />
-            </Button>
-          </div>
-        </div>
-
-        <div ref={bookRef} className="flex gap-1 overflow-x-auto scrollbar-hide pb-2">
-          {bookOfSlotsGames.map((game) => (
-            <Card
-              key={game.id}
-              className="mt-1 ml-1 mr-1 mb-1 flex-shrink-0 w-28 sm:w-32 md:w-36 lg:w-40 rounded-xl overflow-hidden bg-purple-800 transition-shadow hover:ring-2 hover:ring-pink-500 hover:shadow-[0_0_10px_#ff3cac] border-none"
-            >
-              <div className="relative aspect-[4/5]">
-                <Image src={game.image} alt={game.title} fill className="object-cover" />
-              </div>
-            </Card>
-          ))}
-        </div>
-      </div>
+      ))}
 
       {/* Custom Gradient HR */}
       <div className="mt-10 px-4">
@@ -377,7 +113,6 @@ export default function Component() {
           {BOT_USERNAME ? `@${BOT_USERNAME}` : ""}
         </a>
       </div>
-
     </div>
   );
 }

--- a/game-api.json
+++ b/game-api.json
@@ -1,0 +1,26 @@
+{
+  "headers": {
+    "accept": "application/vnd.s.v2+json",
+    "accept-language": "en-US,en;q=0.9",
+    "cache-control": "no-cache",
+    "pragma": "no-cache",
+    "priority": "u=1, i",
+    "sec-ch-ua": "\"Not)A;Brand\";v=\"8\", \"Chromium\";v=\"138\", \"Brave\";v=\"138\"",
+    "sec-ch-ua-arch": "\"x86\"",
+    "sec-ch-ua-full-version-list": "\"Not)A;Brand\";v=\"8.0.0.0\", \"Chromium\";v=\"138.0.0.0\", \"Brave\";v=\"138.0.0.0\"",
+    "sec-ch-ua-mobile": "?0",
+    "sec-ch-ua-model": "\"\"",
+    "sec-ch-ua-platform": "\"Windows\"",
+    "sec-ch-ua-platform-version": "\"10.0.0\"",
+    "sec-fetch-dest": "empty",
+    "sec-fetch-mode": "cors",
+    "sec-fetch-site": "same-origin",
+    "sec-gpc": "1",
+    "tracestate": "dd=s:1;o:rum",
+    "user-agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/138.0.0.0 Safari/537.36",
+    "x-datadog-origin": "rum",
+    "x-datadog-sampling-priority": "1",
+    "x-display-mode": "browser",
+    "Cookie": "first_visited=dHJ1ZQ%3D%3D--7145ed891d367894e80e67781f810a92bd18ee8a; referral_params=eJwrSi3OLy1KTo2OtU0uLSpKzUuuVCtCiCWWlmQAAP5qDf4%3D; _user_visited_app=true; locale=ImVuIg%3D%3D--8d5f0ed8ffa9e7254902ed86823020d385b5435b; trackers=Int9Ig%3D%3D--66dfe43229f08bfea6058da6d59f0480fa495550; _casino_session=eyJ0eXAiOiJKV1QiLCJraWQiOjM4LCJhbGciOiJSUzUxMiJ9.eyJzZXNzaW9uIjoiOTYyNjg4ZTYzYzRlYWI3YmVjNDZiZjg3ZTdjMTBjNmUiLCJ1c2VyX2lkIjoyMDk2MTI0LCJpcCI6IjE3Ni42NS4xMzEuMTcyIiwiY2FzaW5vX2NvZGVuYW1lIjoicGxheWFtbyIsImV4cCI6MTc1NTg5MTUzOSwiaWF0IjoxNzU0MDc3MTM5LCJqdGkiOiJkNGExYjIzYi1lOTg1LTRhMGUtOGUxNC00Yjk2NGFlY2NmNGMifQ.TjJKcUrSNu90xrTuhpU-1s53ELHQa3yNaF2NDl4rcT9I6LSKJVxtF1Q1NcuoRTTk0JR2rbAX113vYof_WezUzbcdAPIZ_2dHBTsxVgqyNqANde4QFo0ekxYBYhPgchbf9EOFgAeL395hen1kp3OGUMXXkFPFVXxMO3eBI13wS0fX20WQp0_eJyJ2csUq11r_v0eM-UAv8NjtjSbfNgtAf5mJ3VIq0l7MU5mSuu5ADNQ8BVZ-4fqRGT-PFni4FGIIeyDy_VUFi70e-xKnJ4GI0Q9EXpbUBiK-35IPCpL_39tAJyvENxPfrGsARn_caBubaKaR1psh11fTfGLTevEw; is_beta_player=false; original_user_id=MjA5NjEyNA%3D%3D--ed3d576d19ea1a03258a6daf2dfe17e90c4ed740;"
+  }
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -8,6 +8,12 @@ const nextConfig = {
   },
   images: {
     unoptimized: true,
+    remotePatterns: [
+      {
+        protocol: 'https',
+        hostname: 'placehold.co',
+      },
+    ],
   },
 }
 

--- a/public/game-codes.json
+++ b/public/game-codes.json
@@ -1,0 +1,13 @@
+[
+  "spribe/plinko/337850",
+  "spribe/aviator/337812",
+  "spribe/dice/337869",
+  "spribe/goal/337907",
+  "spribe/keno/337945",
+  "spribe/mines/337926",
+  "spribe/hilo/337831",
+  "spribe/miniroulette/337888",
+  "spribe/hotline/337964",
+  "spribe/Balloon/440879",
+  "spribe/Trader/504288"
+]

--- a/public/games.json
+++ b/public/games.json
@@ -1,207 +1,89 @@
-[
-  {
-    "title": "Big Bass Bonanza",
-    "image": "/images/games/big_bass_bonanza.png",
-    "rating": 4.9
-  },
-  {
-    "title": "Big Bass Return To The Races",
-    "image": "/images/games/big_bass_return_to_the_races.png",
-    "rating": 4.9
-  },
-  {
-    "title": "Blitz Super Wheel",
-    "image": "/images/games/blitz_super_wheel.png",
-    "rating": 3.8
-  },
-  {
-    "title": "Book Of Monsters",
-    "image": "/images/games/book_of_monsters.png",
-    "rating": 3.7
-  },
-  {
-    "title": "Book Of Atlas",
-    "image": "/images/games/book_of_slots/book_of_atlas.png",
-    "rating": 3.1
-  },
-  {
-    "title": "Book Of Champions",
-    "image": "/images/games/book_of_slots/book_of_champions.png",
-    "rating": 3.2
-  },
-  {
-    "title": "Book Of Dead",
-    "image": "/images/games/book_of_slots/book_of_dead.png",
-    "rating": 3.4
-  },
-  {
-    "title": "Book Of Golden Joker",
-    "image": "/images/games/book_of_slots/book_of_golden_joker.png",
-    "rating": 3.6
-  },
-  {
-    "title": "Book Of Light",
-    "image": "/images/games/book_of_slots/book_of_light.png",
-    "rating": 3.4
-  },
-  {
-    "title": "Book Of Mystic",
-    "image": "/images/games/book_of_slots/book_of_mystic.png",
-    "rating": 3.3
-  },
-  {
-    "title": "Book Of Ra",
-    "image": "/images/games/book_of_slots/book_of_ra.png",
-    "rating": 3.2
-  },
-  {
-    "title": "Book Of Rest",
-    "image": "/images/games/book_of_slots/book_of_rest.png",
-    "rating": 3.7
-  },
-  {
-    "title": "Book Of Sirens",
-    "image": "/images/games/book_of_slots/book_of_sirens.png",
-    "rating": 4.1
-  },
-  {
-    "title": "Book Of The Divine",
-    "image": "/images/games/book_of_slots/book_of_the_divine.png",
-    "rating": 3.8
-  },
-  {
-    "title": "Book Of Tut",
-    "image": "/images/games/book_of_slots/book_of_tut.png",
-    "rating": 4.1
-  },
-  {
-    "title": "Book Of Vikings",
-    "image": "/images/games/book_of_slots/book_of_vikings.png",
-    "rating": 3.8
-  },
-  {
-    "title": "John Hunter And The Book Of Tut",
-    "image": "/images/games/book_of_slots/john_hunter_and_the_book_of_tut.png",
-    "rating": 3.5
-  },
-  {
-    "title": "Buffalo King",
-    "image": "/images/games/buffalo_king.png",
-    "rating": 3.7
-  },
-  {
-    "title": "Aviator",
-    "image": "/images/games/crypto_games/aviator.png",
-    "rating": 4.2
-  },
-  {
-    "title": "Big Bass Crash",
-    "image": "/images/games/crypto_games/big_bass_crash.png",
-    "rating": 3.7
-  },
-  {
-    "title": "Crash Duel X",
-    "image": "/images/games/crypto_games/crash_duel_x.png",
-    "rating": 3
-  },
-  {
-    "title": "Cricket Crash",
-    "image": "/images/games/crypto_games/cricket_crash.png",
-    "rating": 3.4
-  },
-  {
-    "title": "Football Manager",
-    "image": "/images/games/crypto_games/football_manager.png",
-    "rating": 4.3
-  },
-  {
-    "title": "Magnify Man",
-    "image": "/images/games/crypto_games/magnify_man.png",
-    "rating": 3.2
-  },
-  {
-    "title": "Need For X",
-    "image": "/images/games/crypto_games/need_for_x.png",
-    "rating": 3
-  },
-  {
-    "title": "Save The Hamster",
-    "image": "/images/games/crypto_games/save_the_hamster.png",
-    "rating": 3.3
-  },
-  {
-    "title": "Spaceman",
-    "image": "/images/games/crypto_games/spaceman.png",
-    "rating": 4.4
-  },
-  {
-    "title": "Frozen Tropics",
-    "image": "/images/games/frozen_tropics.png",
-    "rating": 3.2
-  },
-  {
-    "title": "Gates Of Olympus",
-    "image": "/images/games/gates_of_olympus.png",
-    "rating": 4.9
-  },
-  {
-    "title": "5 Lions Gold",
-    "image": "/images/games/jackpots/5_lions_gold.png",
-    "rating": 3.1
-  },
-  {
-    "title": "Cosmic Cash",
-    "image": "/images/games/jackpots/cosmic_cash.png",
-    "rating": 4.4
-  },
-  {
-    "title": "Diamond Strike",
-    "image": "/images/games/jackpots/diamond_strike.png",
-    "rating": 3.6
-  },
-  {
-    "title": "Jackpot Hunter",
-    "image": "/images/games/jackpots/jackpot_hunter.png",
-    "rating": 3.6
-  },
-  {
-    "title": "Rainforest Magic Bingo",
-    "image": "/images/games/jackpots/rainforest_magic_bingo.png",
-    "rating": 3.9
-  },
-  {
-    "title": "John Hunter And Galileo",
-    "image": "/images/games/john_hunter_and_galileo.png",
-    "rating": 4.6
-  },
-  {
-    "title": "Lucky Mouse",
-    "image": "/images/games/lucky_mouse.png",
-    "rating": 4.4
-  },
-  {
-    "title": "Lucky Tiger",
-    "image": "/images/games/lucky_tiger.png",
-    "rating": 4.5
-  },
-  {
-    "title": "Plinko",
-    "image": "/images/games/plinko.png",
-    "rating": 4.4
-  },
-  {
-    "title": "Sweet Bonanza",
-    "image": "/images/games/sweet_bonanza.png",
-    "rating": 4.1
-  },
-  {
-    "title": "The Dog House",
-    "image": "/images/games/the_dog_house.png",
-    "rating": 3.9
-  },
-  {
-    "title": "Wild Wild Joker",
-    "image": "/images/games/wild_wild_joker.png",
-    "rating": 4.2
-  }
-]
+{
+  "sections": [
+    {
+      "title": "Top Games",
+      "games": [
+        {
+          "code": "spribe/plinko/337850",
+          "title": "Plinko",
+          "image": "https://placehold.co/400x500/png?text=Plinko"
+        },
+        {
+          "code": "spribe/aviator/337812",
+          "title": "Aviator",
+          "image": "https://placehold.co/400x500/png?text=Aviator"
+        },
+        {
+          "code": "spribe/dice/337869",
+          "title": "Dice",
+          "image": "https://placehold.co/400x500/png?text=Dice"
+        },
+        {
+          "code": "spribe/goal/337907",
+          "title": "Goal",
+          "image": "https://placehold.co/400x500/png?text=Goal"
+        }
+      ]
+    },
+    {
+      "title": "New Games",
+      "games": [
+        {
+          "code": "spribe/plinko/337850",
+          "title": "Plinko",
+          "image": "https://placehold.co/400x500/png?text=Plinko"
+        },
+        {
+          "code": "spribe/aviator/337812",
+          "title": "Aviator",
+          "image": "https://placehold.co/400x500/png?text=Aviator"
+        },
+        {
+          "code": "spribe/dice/337869",
+          "title": "Dice",
+          "image": "https://placehold.co/400x500/png?text=Dice"
+        },
+        {
+          "code": "spribe/goal/337907",
+          "title": "Goal",
+          "image": "https://placehold.co/400x500/png?text=Goal"
+        },
+        {
+          "code": "spribe/keno/337945",
+          "title": "Keno",
+          "image": "https://placehold.co/400x500/png?text=Keno"
+        },
+        {
+          "code": "spribe/mines/337926",
+          "title": "Mines",
+          "image": "https://placehold.co/400x500/png?text=Mines"
+        },
+        {
+          "code": "spribe/hilo/337831",
+          "title": "Hilo",
+          "image": "https://placehold.co/400x500/png?text=Hilo"
+        },
+        {
+          "code": "spribe/miniroulette/337888",
+          "title": "Mini Roulette",
+          "image": "https://placehold.co/400x500/png?text=Mini+Roulette"
+        },
+        {
+          "code": "spribe/hotline/337964",
+          "title": "Hotline",
+          "image": "https://placehold.co/400x500/png?text=Hotline"
+        },
+        {
+          "code": "spribe/Balloon/440879",
+          "title": "Balloon",
+          "image": "https://placehold.co/400x500/png?text=Balloon"
+        },
+        {
+          "code": "spribe/Trader/504288",
+          "title": "Trader",
+          "image": "https://placehold.co/400x500/png?text=Trader"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace hard-coded sections with JSON-driven top/new games
- add game detail page and API route to launch games
- document game codes and API headers in JSON files

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*


------
https://chatgpt.com/codex/tasks/task_e_688e282225588329ac9fe185f20944b6