### PR TITLE
Link header avatar to profile and update footer

### DIFF
--- a/app/sport/page.tsx
+++ b/app/sport/page.tsx
@@ -1,0 +1,3 @@
+export default function SportPage() {
+  return <main className="p-4"></main>;
+}

--- a/components/footer-nav.tsx
+++ b/components/footer-nav.tsx
@@ -1,15 +1,15 @@
 "use client";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { Home, Search, Wallet, DollarSign, User } from "lucide-react";
+import { Home, Search, Trophy, Wallet, DollarSign } from "lucide-react";
 import { Button } from "@/components/ui/button";
 
 const navItems = [
   { href: "/", label: "Home", icon: Home },
   { href: "/search", label: "Search", icon: Search },
+  { href: "/sport", label: "Sport", icon: Trophy },
   { href: "/wallet", label: "Wallet", icon: Wallet },
   { href: "/earn", label: "Earn", icon: DollarSign },
-  { href: "/profile", label: "Profile", icon: User },
 ];
 
 export default function FooterNav() {

--- a/components/header.tsx
+++ b/components/header.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import useTelegramUser from "@/hooks/useTelegramUser";
 import Image from "next/image";
+import Link from "next/link";
 import { Button } from "@/components/ui/button";
 
 export default function Header() {
@@ -17,14 +18,21 @@ export default function Header() {
         <Image src="/ton.svg" alt="TON" width={18} height={18}/>
         <span className="text-sm font-medium">{balance}</span>
       </div>
-      <Button variant="ghost" size="icon" className="w-10 h-10 rounded-full overflow-hidden p-0 ml-3">
-        <Image
-          src={user?.photo_url ?? "https://placehold.co/40x40/EEEEEE/EEEEEE"}
-          alt={user ? `${user.first_name} ${user.last_name ?? ""}` : "Profile"}
-          width={40}
-          height={40}
-          className="object-cover"
-        />
+      <Button
+        variant="ghost"
+        size="icon"
+        className="w-10 h-10 rounded-full overflow-hidden p-0 ml-3"
+        asChild
+      >
+        <Link href="/profile">
+          <Image
+            src={user?.photo_url ?? "https://placehold.co/40x40/EEEEEE/EEEEEE"}
+            alt={user ? `${user.first_name} ${user.last_name ?? ""}` : "Profile"}
+            width={40}
+            height={40}
+            className="object-cover"
+          />
+        </Link>
       </Button>
     </div>
   );


### PR DESCRIPTION
## Summary
- Link header avatar to `/profile` for smooth navigation
- Replace footer profile link with new sport route and reorder nav items
- Add blank `/sport` page

## Testing
- `pnpm lint` *(fails: How would you like to configure ESLint?)*
- `pnpm run test` *(fails: ERR_PNPM_NO_SCRIPT Missing script: test)*

------
https://chatgpt.com/codex/tasks/task_e_688e618963588329824df61b842a7456